### PR TITLE
replace WithDelimiter by WithNameSplitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Add env.WithNameSplitter/flag.WithNameSplitter/pflag.WithNameSplitter to split the name of the flag/env (#110).
+
+### Deprecated
+
+- Deprecate env.WithDelimiter/flag.WithDelimiter/pflag.WithDelimiter in favor of WithNameSplitter (#110).
+
 ## [0.4.0] - 2024-02-07
 
 ### Added

--- a/provider/env/env.go
+++ b/provider/env/env.go
@@ -22,9 +22,9 @@ import (
 //
 // To create a new Env, call New.
 type Env struct {
-	_         [0]func() // Ensure it's incomparable.
-	prefix    string
-	delimiter string
+	_        [0]func() // Ensure it's incomparable.
+	prefix   string
+	splitter func(string) []string
 }
 
 // New creates an Env with the given Option(s).
@@ -33,8 +33,8 @@ func New(opts ...Option) Env {
 	for _, opt := range opts {
 		opt(option)
 	}
-	if option.delimiter == "" {
-		option.delimiter = "_"
+	if option.splitter == nil {
+		option.splitter = func(s string) []string { return strings.Split(s, "_") }
 	}
 
 	return Env(*option)
@@ -49,7 +49,7 @@ func (e Env) Load() (map[string]any, error) {
 				// The environment variable with empty value is treated as unset.
 				continue
 			}
-			maps.Insert(values, strings.Split(key, e.delimiter), value)
+			maps.Insert(values, e.splitter(key), value)
 		}
 	}
 

--- a/provider/env/env.go
+++ b/provider/env/env.go
@@ -22,7 +22,6 @@ import (
 //
 // To create a new Env, call New.
 type Env struct {
-	_        [0]func() // Ensure it's incomparable.
 	prefix   string
 	splitter func(string) []string
 }

--- a/provider/env/env_test.go
+++ b/provider/env/env_test.go
@@ -4,6 +4,7 @@
 package env_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nil-go/konf"
@@ -31,7 +32,12 @@ func TestEnv_Load(t *testing.T) {
 		},
 		{
 			description: "with delimiter",
-			opts:        []env.Option{env.WithPrefix("P."), env.WithDelimiter(".")},
+			opts: []env.Option{
+				env.WithPrefix("P."),
+				env.WithNameSplitter(func(s string) []string {
+					return strings.Split(s, ".")
+				}),
+			},
 			expected: map[string]any{
 				"P": map[string]any{
 					"D": ".",

--- a/provider/env/env_test.go
+++ b/provider/env/env_test.go
@@ -34,9 +34,7 @@ func TestEnv_Load(t *testing.T) {
 			description: "with delimiter",
 			opts: []env.Option{
 				env.WithPrefix("P."),
-				env.WithNameSplitter(func(s string) []string {
-					return strings.Split(s, ".")
-				}),
+				env.WithNameSplitter(func(s string) []string { return strings.Split(s, ".") }),
 			},
 			expected: map[string]any{
 				"P": map[string]any{

--- a/provider/env/option.go
+++ b/provider/env/option.go
@@ -3,6 +3,8 @@
 
 package env
 
+import "strings"
+
 // WithPrefix provides the prefix used when loading environment variables.
 // Only environment variables with names that start with the prefix will be loaded.
 //
@@ -18,9 +20,23 @@ func WithPrefix(prefix string) Option {
 //
 // For example, with the default delimiter "_", an environment variable name like "PARENT_CHILD_KEY"
 // would be split into "PARENT", "CHILD", and "KEY".
+//
+// Deprecated: use WithNameSplitter instead.
 func WithDelimiter(delimiter string) Option {
 	return func(options *options) {
-		options.delimiter = delimiter
+		options.splitter = func(s string) []string {
+			return strings.Split(s, delimiter)
+		}
+	}
+}
+
+// WithNameSplitter provides the function used to split environment variable names into nested keys.
+//
+// For example, with the default splitter, an environment variable name like "PARENT_CHILD_KEY"
+// would be split into "PARENT", "CHILD", and "KEY".
+func WithNameSplitter(splitter func(string) []string) Option {
+	return func(options *options) {
+		options.splitter = splitter
 	}
 }
 

--- a/provider/flag/flag_test.go
+++ b/provider/flag/flag_test.go
@@ -5,6 +5,7 @@ package flag_test
 
 import (
 	"flag"
+	"strings"
 	"sync"
 	"testing"
 
@@ -41,7 +42,12 @@ func TestFlag_Load(t *testing.T) {
 		},
 		{
 			description: "with delimiter",
-			opts:        []kflag.Option{kflag.WithDelimiter("_"), kflag.WithPrefix("p_")},
+			opts: []kflag.Option{
+				kflag.WithPrefix("p_"),
+				kflag.WithNameSplitter(func(s string) []string {
+					return strings.Split(s, "_")
+				}),
+			},
 			expected: map[string]any{
 				"p": map[string]any{
 					"d": "_",

--- a/provider/flag/flag_test.go
+++ b/provider/flag/flag_test.go
@@ -44,9 +44,7 @@ func TestFlag_Load(t *testing.T) {
 			description: "with delimiter",
 			opts: []kflag.Option{
 				kflag.WithPrefix("p_"),
-				kflag.WithNameSplitter(func(s string) []string {
-					return strings.Split(s, "_")
-				}),
+				kflag.WithNameSplitter(func(s string) []string { return strings.Split(s, "_") }),
 			},
 			expected: map[string]any{
 				"p": map[string]any{

--- a/provider/flag/option.go
+++ b/provider/flag/option.go
@@ -3,7 +3,10 @@
 
 package flag
 
-import "flag"
+import (
+	"flag"
+	"strings"
+)
 
 // WithPrefix provides the prefix used when loading flags.
 // Only flags with names that start with the prefix will be loaded.
@@ -29,9 +32,23 @@ func WithFlagSet(set *flag.FlagSet) Option {
 //
 // For example, with the default delimiter ".", an flag name like "parent.child.key"
 // would be split into "parent", "child", and "key".
+//
+// Deprecated: use WithNameSplitter instead.
 func WithDelimiter(delimiter string) Option {
 	return func(options *options) {
-		options.delimiter = delimiter
+		options.splitter = func(s string) []string {
+			return strings.Split(s, delimiter)
+		}
+	}
+}
+
+// WithNameSplitter provides the function used to split environment variable names into nested keys.
+//
+// For example, with the default splitter, an flag name like "parent.child.key"
+// would be split into "parent", "child", and "key".
+func WithNameSplitter(splitter func(string) []string) Option {
+	return func(options *options) {
+		options.splitter = splitter
 	}
 }
 

--- a/provider/pflag/option.go
+++ b/provider/pflag/option.go
@@ -3,7 +3,11 @@
 
 package pflag
 
-import "github.com/spf13/pflag"
+import (
+	"strings"
+
+	"github.com/spf13/pflag"
+)
 
 // WithPrefix provides the prefix used when loading flags.
 // Only flags with names that start with the prefix will be loaded.
@@ -29,9 +33,23 @@ func WithFlagSet(set *pflag.FlagSet) Option {
 //
 // For example, with the default delimiter ".", an flag name like "parent.child.key"
 // would be split into "parent", "child", and "key".
+//
+// Deprecated: use WithNameSplitter instead.
 func WithDelimiter(delimiter string) Option {
 	return func(options *options) {
-		options.delimiter = delimiter
+		options.splitter = func(s string) []string {
+			return strings.Split(s, delimiter)
+		}
+	}
+}
+
+// WithNameSplitter provides the function used to split environment variable names into nested keys.
+//
+// For example, with the default splitter, an flag name like "parent.child.key"
+// // would be split into "parent", "child", and "key".
+func WithNameSplitter(splitter func(string) []string) Option {
+	return func(options *options) {
+		options.splitter = splitter
 	}
 }
 

--- a/provider/pflag/pflag_test.go
+++ b/provider/pflag/pflag_test.go
@@ -5,6 +5,7 @@ package pflag_test
 
 import (
 	"flag"
+	"strings"
 	"testing"
 
 	"github.com/spf13/pflag"
@@ -35,14 +36,24 @@ func TestPFlag_Load(t *testing.T) {
 	}{
 		{
 			description: "with flag set",
-			opts:        []kflag.Option{kflag.WithFlagSet(set), kflag.WithDelimiter("_")},
+			opts: []kflag.Option{
+				kflag.WithFlagSet(set),
+				kflag.WithNameSplitter(func(s string) []string {
+					return strings.Split(s, "_")
+				}),
+			},
 			expected: map[string]any{
 				"k": "v",
 			},
 		},
 		{
 			description: "with delimiter",
-			opts:        []kflag.Option{kflag.WithDelimiter("_"), kflag.WithPrefix("p_")},
+			opts: []kflag.Option{
+				kflag.WithPrefix("p_"),
+				kflag.WithNameSplitter(func(s string) []string {
+					return strings.Split(s, "_")
+				}),
+			},
 			expected: map[string]any{
 				"p": map[string]any{
 					"d": "_",

--- a/provider/pflag/pflag_test.go
+++ b/provider/pflag/pflag_test.go
@@ -38,9 +38,7 @@ func TestPFlag_Load(t *testing.T) {
 			description: "with flag set",
 			opts: []kflag.Option{
 				kflag.WithFlagSet(set),
-				kflag.WithNameSplitter(func(s string) []string {
-					return strings.Split(s, "_")
-				}),
+				kflag.WithNameSplitter(func(s string) []string { return strings.Split(s, "_") }),
 			},
 			expected: map[string]any{
 				"k": "v",
@@ -50,9 +48,7 @@ func TestPFlag_Load(t *testing.T) {
 			description: "with delimiter",
 			opts: []kflag.Option{
 				kflag.WithPrefix("p_"),
-				kflag.WithNameSplitter(func(s string) []string {
-					return strings.Split(s, "_")
-				}),
+				kflag.WithNameSplitter(func(s string) []string { return strings.Split(s, "_") }),
 			},
 			expected: map[string]any{
 				"p": map[string]any{


### PR DESCRIPTION
It uses WithDelimiter to customize splitting name of env/flag, which is pretty limited. This PR replace it with WithNameSplitter which is superset of WithDelimiter.