### PR TITLE
fix: flag and pflag always add the default value even the key exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.1] - 2024--3-10
+
+### Fixed
+
+- flag and pflag always add the default value even the key already exists
+  since konf.Exists uses empty delimiter for empty Config (#228).
+
 ## [0.9.0] - 2024-03-10
 
 ### Added

--- a/config.go
+++ b/config.go
@@ -145,15 +145,19 @@ func (c *Config) log(ctx context.Context, level slog.Level, message string, attr
 }
 
 func (c *Config) sub(values map[string]any, path string) any {
-	delimiter := c.delimiter
-	if delimiter == "" {
-		delimiter = "."
-	}
 	if !c.caseSensitive {
 		path = toLower(path)
 	}
 
-	return maps.Sub(values, strings.Split(path, delimiter))
+	return maps.Sub(values, strings.Split(path, c.delim()))
+}
+
+func (c *Config) delim() string {
+	if c.delimiter == "" {
+		return "."
+	}
+
+	return c.delimiter
 }
 
 func (c *Config) transformKeys(m map[string]any) map[string]any {
@@ -185,14 +189,9 @@ func (c *Config) Explain(path string) string {
 }
 
 func (c *Config) explain(explanation *strings.Builder, path string, value any) {
-	delimiter := c.delimiter
-	if delimiter == "" {
-		delimiter = "."
-	}
-
 	if values, ok := value.(map[string]any); ok {
 		for k, v := range values {
-			c.explain(explanation, path+delimiter+k, v)
+			c.explain(explanation, path+c.delim()+k, v)
 		}
 
 		return

--- a/provider.go
+++ b/provider.go
@@ -42,5 +42,5 @@ func (c *Config) Exists(path []string) bool {
 
 	c.nocopy.Check()
 
-	return c.sub(c.values, strings.Join(path, c.delimiter)) != nil
+	return c.sub(c.values, strings.Join(path, c.delim())) != nil
 }

--- a/provider_test.go
+++ b/provider_test.go
@@ -12,7 +12,12 @@ import (
 
 func TestConfig_Exists(t *testing.T) {
 	var config konf.Config
-	assert.NoError(t, config.Load(mapLoader{"config": "string"}))
-	assert.True(t, config.Exists([]string{"config"}))
+	assert.NoError(t, config.Load(mapLoader{"config": map[string]any{"a": "string"}}))
+	assert.True(t, config.Exists([]string{"config", "a"}))
+	assert.True(t, !config.Exists([]string{"other"}))
+
+	config = *konf.New(konf.WithDelimiter("/"))
+	assert.NoError(t, config.Load(mapLoader{"config": map[string]any{"a": "string"}}))
+	assert.True(t, config.Exists([]string{"config", "a"}))
 	assert.True(t, !config.Exists([]string{"other"}))
 }


### PR DESCRIPTION
since konf.Exists uses empty delimiter for empty Config