### PR TITLE
preserve the case for key of map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Explain supports empty string as path (#314).
+- Reserve the case for key of map when unmarshalling (#318).
 
 ## [1.1.0] - 2024-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Explain supports empty string as path (#314).
-- Reserve the case for key of map when unmarshalling (#318).
+- Reserve the case for key of map when unmarshalling. All keys in map used to be lower case,
+  now it matches the case in the configuration (#318).
 
 ## [1.1.0] - 2024-04-24
 

--- a/config.go
+++ b/config.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unicode"
 
 	"github.com/nil-go/konf/internal"
 	"github.com/nil-go/konf/internal/convert"
@@ -147,7 +146,7 @@ func (c *Config) log(ctx context.Context, level slog.Level, message string, attr
 
 func (c *Config) sub(values map[string]any, path string) any {
 	if !c.caseSensitive {
-		path = toLower(path)
+		path = strings.ToLower(path)
 	}
 
 	return maps.Sub(values, path, c.delim())
@@ -163,12 +162,8 @@ func (c *Config) delim() string {
 
 func (c *Config) transformKeys(m map[string]any) {
 	if !c.caseSensitive {
-		maps.TransformKeys(m, toLower)
+		maps.TransformKeys(m, strings.ToLower)
 	}
-}
-
-func toLower(s string) string {
-	return strings.Map(unicode.ToLower, s)
 }
 
 // Explain provides information about how Config resolve each value
@@ -246,7 +241,7 @@ type provider struct {
 //nolint:gochecknoglobals
 var (
 	defaultTagName = convert.WithTagName("konf")
-	defaultKeyMap  = convert.WithKeyMapper(toLower)
+	defaultKeyMap  = convert.WithKeyMapper(strings.ToLower)
 	defaultHooks   = []convert.Option{
 		convert.WithHook[string, time.Duration](time.ParseDuration),
 		convert.WithHook[string, []string](func(f string) ([]string, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -84,6 +84,15 @@ func TestConfig_Unmarshal(t *testing.T) {
 			},
 		},
 		{
+			description: "config for map",
+			loaders:     []konf.Loader{mapLoader{"Config": "struct"}},
+			assert: func(config *konf.Config) {
+				var value map[string]string
+				assert.NoError(t, config.Unmarshal("", &value))
+				assert.Equal(t, "struct", value["Config"])
+			},
+		},
+		{
 			description: "config for struct",
 			loaders:     []konf.Loader{mapLoader{"config": "struct"}},
 			assert: func(config *konf.Config) {

--- a/internal/convert/converter_test.go
+++ b/internal/convert/converter_test.go
@@ -650,7 +650,7 @@ func TestConverter(t *testing.T) { //nolint:maintidx
 		},
 		{
 			description: "map to map (key convert error)",
-			from:        map[string]int{"-2": -42},
+			from:        map[string]int{"-2": 42},
 			to:          pointer(map[uint]uint(nil)),
 			err:         "cannot parse '[-2]' as uint: strconv.ParseUint: parsing \"-2\": invalid syntax",
 		},

--- a/internal/maps/sub.go
+++ b/internal/maps/sub.go
@@ -5,21 +5,18 @@ package maps
 
 import "strings"
 
-func Sub(values map[string]any, path string, delimiter string) (value any) { //nolint:nonamedreturns
+func Sub(values map[string]any, path string, delimiter string) any {
 	if path == "" {
 		return values
 	}
 
-	defer func() {
-		_, value = Unpack(value)
-	}()
-
 	key, path, _ := strings.Cut(path, delimiter)
+	_, value := Unpack(values[key])
 	if path == "" {
-		return values[key]
+		return value
 	}
 
-	if mp, ok := values[key].(map[string]any); ok {
+	if mp, ok := value.(map[string]any); ok {
 		return Sub(mp, path, delimiter)
 	}
 

--- a/internal/maps/sub.go
+++ b/internal/maps/sub.go
@@ -11,11 +11,7 @@ func Sub(values map[string]any, path string, delimiter string) (value any) { //n
 	}
 
 	defer func() {
-		switch v := value.(type) {
-		case KeyValue:
-			value = v.Value
-		default:
-		}
+		_, value = Unpack(value)
 	}()
 
 	key, path, _ := strings.Cut(path, delimiter)

--- a/internal/maps/sub.go
+++ b/internal/maps/sub.go
@@ -5,10 +5,18 @@ package maps
 
 import "strings"
 
-func Sub(values map[string]any, path string, delimiter string) any {
+func Sub(values map[string]any, path string, delimiter string) (value any) { //nolint:nonamedreturns
 	if path == "" {
 		return values
 	}
+
+	defer func() {
+		switch v := value.(type) {
+		case KeyValue:
+			value = v.Value
+		default:
+		}
+	}()
 
 	key, path, _ := strings.Cut(path, delimiter)
 	if path == "" {

--- a/internal/maps/sub_test.go
+++ b/internal/maps/sub_test.go
@@ -56,6 +56,12 @@ func TestSub(t *testing.T) {
 			expected:    1,
 		},
 		{
+			description: "keyvalue",
+			values:      map[string]any{"a": maps.KeyValue{Key: "A", Value: 1}},
+			path:        "a",
+			expected:    1,
+		},
+		{
 			description: "value not exist",
 			values:      map[string]any{"a": 1},
 			path:        "a.b",

--- a/internal/maps/sub_test.go
+++ b/internal/maps/sub_test.go
@@ -57,7 +57,7 @@ func TestSub(t *testing.T) {
 		},
 		{
 			description: "keyvalue",
-			values:      map[string]any{"a": maps.KeyValue{Key: "A", Value: 1}},
+			values:      map[string]any{"a": maps.Pack("A", 1)},
 			path:        "a",
 			expected:    1,
 		},

--- a/internal/maps/transform.go
+++ b/internal/maps/transform.go
@@ -14,7 +14,7 @@ func TransformKeys(src map[string]interface{}, keyMap func(string) string) {
 		newKey := keyMap(key)
 		if newKey != key {
 			delete(src, key)
-			src[newKey] = value
+			src[newKey] = KeyValue{Key: key, Value: value}
 		}
 	}
 }

--- a/internal/maps/transform.go
+++ b/internal/maps/transform.go
@@ -14,7 +14,7 @@ func TransformKeys(src map[string]interface{}, keyMap func(string) string) {
 		newKey := keyMap(key)
 		if newKey != key {
 			delete(src, key)
-			src[newKey] = KeyValue{Key: key, Value: value}
+			src[newKey] = Pack(key, value)
 		}
 	}
 }

--- a/internal/maps/transform_test.go
+++ b/internal/maps/transform_test.go
@@ -33,7 +33,7 @@ func TestTransformKeys(t *testing.T) {
 			description: "transform keys",
 			src:         map[string]any{"A": map[string]any{"X": 1, "y": 2}},
 			keyMap:      strings.ToLower,
-			expected:    map[string]any{"a": map[string]any{"x": 1, "y": 2}},
+			expected:    map[string]any{"a": maps.KeyValue{Key: "A", Value: map[string]any{"x": maps.KeyValue{Key: "X", Value: 1}, "y": 2}}},
 		},
 	}
 

--- a/internal/maps/transform_test.go
+++ b/internal/maps/transform_test.go
@@ -33,7 +33,7 @@ func TestTransformKeys(t *testing.T) {
 			description: "transform keys",
 			src:         map[string]any{"A": map[string]any{"X": 1, "y": 2}},
 			keyMap:      strings.ToLower,
-			expected:    map[string]any{"a": maps.KeyValue{Key: "A", Value: map[string]any{"x": maps.KeyValue{Key: "X", Value: 1}, "y": 2}}},
+			expected:    map[string]any{"a": maps.Pack("A", map[string]any{"x": maps.Pack("X", 1), "y": 2})},
 		},
 	}
 

--- a/internal/maps/value.go
+++ b/internal/maps/value.go
@@ -7,3 +7,15 @@ type KeyValue struct {
 	Key   string
 	Value any
 }
+
+func Pack(key string, value any) KeyValue {
+	return KeyValue{Key: key, Value: value}
+}
+
+func Unpack(value any) (string, any) {
+	if v, ok := value.(KeyValue); ok {
+		return v.Key, v.Value
+	}
+
+	return "", value
+}

--- a/internal/maps/value.go
+++ b/internal/maps/value.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2024 The konf authors
+// Use of this source code is governed by a MIT license found in the LICENSE file.
+
+package maps
+
+type KeyValue struct {
+	Key   string
+	Value any
+}

--- a/watch.go
+++ b/watch.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -175,7 +176,7 @@ func (c *Config) OnChange(onChange func(*Config), paths ...string) {
 	}
 	for _, path := range paths {
 		if !c.caseSensitive {
-			path = toLower(path)
+			path = strings.ToLower(path)
 		}
 		c.onChanges[path] = append(c.onChanges[path], onChange)
 	}


### PR DESCRIPTION
currently if the target has map, all keys in map are lower case by default due to case-insensitive. This PR fixes it by preserving the original case for keys in map