### PR TITLE
Add spf13/cobra instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ There are providers for the following configuration sources.
 | [`secretmanager`](provider/secretmanager) | [GCP Secret Manager](https://cloud.google.com/security/products/secret-manager)         |       ✓       | [pubsub](notifier/pubsub) |
 | [`gcs`](provider/gcs)                     | [GCP Cloud Storage](https://cloud.google.com/storage)                                   |       ✓       | [pubsub](notifier/pubsub) |
 
+[cobra](https://github.com/spf13/cobra) is supported through the [`pflag`](provider/pflag) loader, with the `WithFlagSet` option:  
+```go
+config.Load(kflag.New(&config, kflag.WithFlagSet(yourCobraCmd.Flags())))
+```
+
 ## Custom Configuration Providers
 
 You can Custom provider by implementing the `Loader` for static configuration loader (e.g [`fs`](provider/fs))

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ There are providers for the following configuration sources.
 | [`secretmanager`](provider/secretmanager) | [GCP Secret Manager](https://cloud.google.com/security/products/secret-manager)         |       ✓       | [pubsub](notifier/pubsub) |
 | [`gcs`](provider/gcs)                     | [GCP Cloud Storage](https://cloud.google.com/storage)                                   |       ✓       | [pubsub](notifier/pubsub) |
 
-[cobra](https://github.com/spf13/cobra) is supported through the [`pflag`](provider/pflag) loader, with the `WithFlagSet` option:  
+[cobra](https://github.com/spf13/cobra) is supported through the [`pflag`](provider/pflag) loader, with the [`pflag.WithFlagSet`](https://pkg.go.dev/github.com/nil-go/konf/provider/pflag#WithFlagSet) option:  
 ```go
 config.Load(kflag.New(&config, kflag.WithFlagSet(yourCobraCmd.Flags())))
 ```

--- a/provider/pflag/option.go
+++ b/provider/pflag/option.go
@@ -21,7 +21,6 @@ func WithPrefix(prefix string) Option {
 // WithFlagSet provides the [pflag.FlagSet] that loads configuration from.
 //
 // The default flag set is [pflag.CommandLine] plus [flag.CommandLine].
-// WithFlagSet allows to use spf13/cobra and pass the flag set to the pflag loader.
 func WithFlagSet(set *pflag.FlagSet) Option {
 	return func(options *options) {
 		options.set = set

--- a/provider/pflag/option.go
+++ b/provider/pflag/option.go
@@ -21,6 +21,7 @@ func WithPrefix(prefix string) Option {
 // WithFlagSet provides the [pflag.FlagSet] that loads configuration from.
 //
 // The default flag set is [pflag.CommandLine] plus [flag.CommandLine].
+// WithFlagSet allows to use spf13/cobra and pass the flag set to the pflag loader.
 func WithFlagSet(set *pflag.FlagSet) Option {
 	return func(options *options) {
 		options.set = set


### PR DESCRIPTION
This PR adds a little notice to explain how to use Cobra in the README ~~and in the godoc of pflag.WithFlagSet~~.  

At first I thought it was not supported, I tried to use the `pflag` loader without the `WithFlagSet` option and got errors (undefined flag xxx), so I think it might be helpful to add this info.
Let me know if the format doesn't suits you or if you have any other suggestion.

Thanks!