### PR TITLE
Fixed parent context overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Overwriting parent context in `*Config.Watch()` what led to unwanted routine exit.
+
 ## [1.2.0] - 2024-06-10
 
 ### Changed

--- a/watch.go
+++ b/watch.go
@@ -70,14 +70,13 @@ func (c *Config) Watch(ctx context.Context) error { //nolint:cyclop,funlen,gocog
 							}
 						}()
 
-						var tcancel context.CancelFunc
-						ctx, tcancel = context.WithTimeout(ctx, time.Minute)
+						tctx, tcancel := context.WithTimeout(ctx, time.Minute)
 						defer tcancel()
 						select {
 						case <-done:
 							c.log(ctx, slog.LevelDebug, "Configuration has been applied to onChanges.")
-						case <-ctx.Done():
-							if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+						case <-tctx.Done():
+							if errors.Is(tctx.Err(), context.DeadlineExceeded) {
 								c.log(
 									ctx, slog.LevelWarn,
 									"Configuration has not been fully applied to onChanges due to timeout."+


### PR DESCRIPTION
Overwriting parent context led to the routine at :49 unwanted exit.