### PR TITLE
Fixed data race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Overwriting parent context in `*Config.Watch()` what led to unwanted routine exit.
+- Fixed data race occurred in `*Config.values`, `*Config.providers` and `provider.values`. See related PR for details.
 
 ## [1.2.0] - 2024-06-10
 


### PR DESCRIPTION
Fixed data race occurred in `*Config.values`, `*Config.providers` and `provider.values`.
`go test` log:
```
WARNING: DATA RACE
Write at 0x00c0001af9a8 by goroutine 34:
  github.com/nil-go/konf.(*Config).Watch.func3.1()
      /go/pkg/mod/github.com/nil-go/konf@v1.2.1-0.20240613001052-a88c18635dda/watch.go:108 +0x116
  github.com/nil-go/konf/provider/file.(*File).Watch()
      /go/pkg/mod/github.com/nil-go/konf/provider/file@v1.2.0/watch.go:84 +0xb4c
  github.com/nil-go/konf.(*Config).Watch.func3()
      /go/pkg/mod/github.com/nil-go/konf@v1.2.1-0.20240613001052-a88c18635dda/watch.go:135 +0x3e6
  github.com/nil-go/konf.(*Config).Watch.gowrap3()
      /go/pkg/mod/github.com/nil-go/konf@v1.2.1-0.20240613001052-a88c18635dda/watch.go:138 +0x4f
Previous read at 0x00c0001af9a8 by goroutine 32:
  github.com/nil-go/konf.(*Config).Watch.func2()
      /go/pkg/mod/github.com/nil-go/konf@v1.2.1-0.20240613001052-a88c18635dda/watch.go:56 +0x2fa
Goroutine 34 (running) created at:
  github.com/nil-go/konf.(*Config).Watch()
      /go/pkg/mod/github.com/nil-go/konf@v1.2.1-0.20240613001052-a88c18635dda/watch.go:101 +0x88c
WARNING: DATA RACE
Write at 0x00c0003302d0 by goroutine 32:
  github.com/nil-go/konf.(*Config).Watch.func2()
      /go/pkg/mod/github.com/nil-go/konf@v1.2.1-0.20240613001052-a88c18635dda/watch.go:59 +0x207
Previous read at 0x00c0003302d0 by goroutine 43:
  github.com/nil-go/konf.(*Config).Unmarshal()
      /go/pkg/mod/github.com/nil-go/konf@v1.2.1-0.20240613001052-a88c18635dda/config.go:133 +0x146

```