### PR TITLE
use atomic.Pointer for map to avoid race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
-- Overwriting parent context in `*Config.Watch()` what led to unwanted routine exit.
+- Overwriting parent context in `*Config.Watch()` what led to unwanted routine exit (#370).
+- Use atomic.Pointer for Config.values and provider.values to avoid race condition (#378).
 
 ## [1.2.0] - 2024-06-10
 

--- a/default_test.go
+++ b/default_test.go
@@ -80,7 +80,7 @@ func TestOnChange(t *testing.T) {
 		assert.NoError(t, konf.Unmarshal("config", &value))
 		newValue <- value
 	}, "config")
-	watcher.change("changed")
+	watcher.change()
 	assert.Equal(t, "changed", <-newValue)
 }
 

--- a/provider.go
+++ b/provider.go
@@ -42,5 +42,5 @@ func (c *Config) Exists(path []string) bool {
 
 	c.nocopy.Check()
 
-	return c.sub(c.values, strings.Join(path, c.delim())) != nil
+	return c.sub(*c.values.Load(), strings.Join(path, c.delim())) != nil
 }


### PR DESCRIPTION
Although simple pointer also works since konf allows near latest value but it's annoying since it always fails race test.