### PR TITLE
Support converting into INT slices from environments variables

### DIFF
--- a/internal/convert/converter.go
+++ b/internal/convert/converter.go
@@ -432,17 +432,15 @@ func (c Converter) convertSlice(name string, fromVal, toVal reflect.Value) error
 		parts := strings.Split(fromVal.String(), ",")
 
 		toVal.Clear()
-		needed := len(parts)
-		if toVal.Cap() < needed {
-			toVal.Grow(needed - toVal.Cap())
+		if toVal.Cap() < len(parts) {
+			toVal.Grow(len(parts) - toVal.Cap())
 		}
-		toVal.SetLen(needed)
+		toVal.SetLen(len(parts))
 
 		errs := make([]error, 0, len(parts))
 		for i, part := range parts {
 			fieldName := name + "[" + strconv.Itoa(i) + "]"
 			toElemVal := toVal.Index(i)
-
 			if err := c.convert(fieldName, strings.TrimSpace(part), pointer(toElemVal)); err != nil {
 				errs = append(errs, err)
 			}

--- a/internal/convert/converter.go
+++ b/internal/convert/converter.go
@@ -464,8 +464,6 @@ func (c Converter) convertSlice(name string, fromVal, toVal reflect.Value) error
 		// Just re-try this function with data as a slice.
 		return c.convertSlice(name, reflect.ValueOf([]any{fromVal.Interface()}), toVal)
 	}
-
-	return nil
 }
 
 func (c Converter) convertString(name string, fromVal, toVal reflect.Value) error { //nolint:cyclop

--- a/internal/convert/converter_test.go
+++ b/internal/convert/converter_test.go
@@ -1017,6 +1017,42 @@ func TestConverter(t *testing.T) { //nolint:maintidx
 			to:          pointer(any(nil)),
 			expected:    pointer(any(nil)),
 		},
+		{
+			description: "comma-separated string to []string",
+			from:        "alpha,beta,gamma",
+			to:          pointer([]string(nil)),
+			expected:    pointer([]string{"alpha", "beta", "gamma"}),
+		},
+		{
+			description: "comma-separated string to []int",
+			from:        "42,100,200",
+			to:          pointer([]int(nil)),
+			expected:    pointer([]int{42, 100, 200}),
+		},
+		{
+			description: "comma-separated string with spaces to []int",
+			from:        " 42,  100 ,  300 ",
+			to:          pointer([]int(nil)),
+			expected:    pointer([]int{42, 100, 300}),
+		},
+		{
+			description: "comma-separated string with empty element to []int",
+			from:        "42,,100",
+			to:          pointer([]int(nil)),
+			expected:    pointer([]int{42, 0, 100}),
+		},
+		{
+			description: "comma-separated string to []int (invalid element)",
+			from:        "42,foo,100",
+			to:          pointer([]int(nil)),
+			err:         "cannot parse '[1]' as int: strconv.ParseInt: parsing \"foo\": invalid syntax",
+		},
+		{
+			description: "comma-separated string to []float64",
+			from:        "3.14,2.71",
+			to:          pointer([]float64(nil)),
+			expected:    pointer([]float64{3.14, 2.71}),
+		},
 		// unsupported.
 		{
 			description: "to func (unsupported)",

--- a/internal/convert/option.go
+++ b/internal/convert/option.go
@@ -33,7 +33,7 @@ func WithHook[F, T any, FN func(F) (T, error) | func(F, T) error](hook FN) Optio
 			return nil
 		})
 	case func(F, T) error:
-		return withHookFunc[F, T](hookFunc)
+		return withHookFunc(hookFunc)
 	default:
 		return func(*options) {}
 	}

--- a/internal/string.go
+++ b/internal/string.go
@@ -3,7 +3,9 @@
 
 package internal
 
-import "unsafe"
+import (
+	"unsafe"
+)
 
 func String2ByteSlice(str string) []byte {
 	if str == "" {


### PR DESCRIPTION
fixes #672 

If defining arrays in environments variables separated by `,` its comes into `Convert` as string